### PR TITLE
testnet: Add initial testnet token mapping for Renegade sequencer

### DIFF
--- a/testnet.json
+++ b/testnet.json
@@ -1,0 +1,148 @@
+{
+    "tokens": [
+        {
+            "name": "DUMMY1",
+            "ticker": "DUMMY1",
+            "address": "0x7e32b54800705876d3b5cfbc7d9c226a211f7c1a",
+            "decimals": 18
+        },
+        {
+            "name": "DUMMY2",
+            "ticker": "DUMMY2",
+            "address": "0x85d9a8a4bd77b9b5559c1b7fcb8ec9635922ed49",
+            "decimals": 18
+        },
+        {
+            "name": "WBTC",
+            "ticker": "WBTC",
+            "address": "0x96c6cf4afdafb835cdd5a8259a0cedd8195895a9",
+            "decimals": 18
+        },
+        {
+            "name": "WETH",
+            "ticker": "WETH",
+            "address": "0xbeb41fc8fe10b648472cb4b98ed86cb454bf3f3b",
+            "decimals": 18
+        },
+        {
+            "name": "BNB",
+            "ticker": "BNB",
+            "address": "0x20b66b007395c0a2420b4152679ffc51dc2a2cb5",
+            "decimals": 18
+        },
+        {
+            "name": "MATIC",
+            "ticker": "MATIC",
+            "address": "0xe32ac7e413b819007caa594ef679a5876c043e84",
+            "decimals": 18
+        },
+        {
+            "name": "LDO",
+            "ticker": "LDO",
+            "address": "0x451149b4e14eca8fddebc5af0f49af02aa66be07",
+            "decimals": 18
+        },
+        {
+            "name": "CBETH",
+            "ticker": "CBETH",
+            "address": "0x59b7f0b6a975833577bcf7bc0f82fbd993fa36e9",
+            "decimals": 18
+        },
+        {
+            "name": "USDC",
+            "ticker": "USDC",
+            "address": "0x4517bab8ec4976f632569b09193405c322e0ccd0",
+            "decimals": 18
+        },
+        {
+            "name": "USDT",
+            "ticker": "USDT",
+            "address": "0xc477b03842638253a0a96a8ab3107afa0e44b215",
+            "decimals": 18
+        },
+        {
+            "name": "BUSD",
+            "ticker": "BUSD",
+            "address": "0xf593463536021d4fbf6b8d7b81171b47ea18ceaf",
+            "decimals": 18
+        },
+        {
+            "name": "LINK",
+            "ticker": "LINK",
+            "address": "0x6291bee08be93d8034dce97f7d00a874c2f5f1ab",
+            "decimals": 18
+        },
+        {
+            "name": "UNI",
+            "ticker": "UNI",
+            "address": "0x9cfece731f0e834d61564e7d29eaad1ab2eb2b7c",
+            "decimals": 18
+        },
+        {
+            "name": "SUSHI",
+            "ticker": "SUSHI",
+            "address": "0xfad0e41327c1b54d5c0cf747c6a443f2015d6364",
+            "decimals": 18
+        },
+        {
+            "name": "1INCH",
+            "ticker": "1INCH",
+            "address": "0xda2e8b6c26ab68d3a2c36fb161fc07a40d30c05b",
+            "decimals": 18
+        },
+        {
+            "name": "AAVE",
+            "ticker": "AAVE",
+            "address": "0x31d9e6922eb67924baa1cd5027dda4b3c01f55dc",
+            "decimals": 18
+        },
+        {
+            "name": "COMP",
+            "ticker": "COMP",
+            "address": "0x9708171ebfa3575ce3e4b77d780682a5ec972276",
+            "decimals": 18
+        },
+        {
+            "name": "MKR",
+            "ticker": "MKR",
+            "address": "0xf5cc5747ba5e6aaacfccfe90ed25fec4a33ff516",
+            "decimals": 18
+        },
+        {
+            "name": "TORN",
+            "ticker": "TORN",
+            "address": "0xcc7761dfea53f2e3b4a209d0d386e080a3f12083",
+            "decimals": 18
+        },
+        {
+            "name": "REN",
+            "ticker": "REN",
+            "address": "0x26fd58a6d8becebd2d8a280c1d154b27fa71409f",
+            "decimals": 18
+        },
+        {
+            "name": "RNG",
+            "ticker": "RNG",
+            "address": "0xa0504cba364b761d44bd3e0b02ea59c0cd669304",
+            "decimals": 18
+        },
+        {
+            "name": "SHIB",
+            "ticker": "SHIB",
+            "address": "0xaf7a3ad90e366f3a5f162c785eb9bce2213ff425",
+            "decimals": 18
+        },
+        {
+            "name": "MANA",
+            "ticker": "MANA",
+            "address": "0x31059a7c98d3bb5ad1e4d56344778b0e1b866392",
+            "decimals": 18
+        },
+        {
+            "name": "ENS",
+            "ticker": "ENS",
+            "address": "0xee46871eb341fff7740f68f9c7d5ca7313f7c666",
+            "decimals": 18
+        }
+    ]
+}


### PR DESCRIPTION
### Purpose
This PR adds the initial token mapping for the Renegade testnet sequencer deployed at `http://35.183.100.90:8547`.

The format is inspired by the [Trustwallet mapping](https://github.com/trustwallet/assets/blob/master/blockchains/ethereum/tokenlist.json)