### PR TITLE
testnet: Use WETH addr with wrapper functionality

### DIFF
--- a/testnet.json
+++ b/testnet.json
@@ -21,7 +21,7 @@
     {
       "name": "Wrapped Ether",
       "ticker": "WETH",
-      "address": "0xcf8a4dbdc5c23a599bf045784b3740b1722c86dd",
+      "address": "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a",
       "decimals": 18
     },
     {


### PR DESCRIPTION
### Purpose
This PR updates the WETH addr to one that implements wrapper functionality of native ETH