### PR TITLE
usdc: set kraken ticker to USDC

### DIFF
--- a/arbitrum-one.json
+++ b/arbitrum-one.json
@@ -8,7 +8,7 @@
             "supported_exchanges": {
                 "Binance": "USDC",
                 "Coinbase": "USD",
-                "Kraken": "USD",
+                "Kraken": "USDC",
                 "Okx": "USDC"
             },
             "chain_addresses": {

--- a/arbitrum-sepolia.json
+++ b/arbitrum-sepolia.json
@@ -8,7 +8,7 @@
       "supported_exchanges": {
         "Binance": "USDC",
         "Coinbase": "USD",
-        "Kraken": "USD",
+        "Kraken": "USDC",
         "Okx": "USDC"
       },
       "chain_addresses": {

--- a/base-mainnet.json
+++ b/base-mainnet.json
@@ -8,7 +8,7 @@
             "supported_exchanges": {
                 "Binance": "USDC",
                 "Coinbase": "USD",
-                "Kraken": "USD",
+                "Kraken": "USDC",
                 "Okx": "USDC"
             },
             "canonical_exchange": "Binance"

--- a/base-sepolia.json
+++ b/base-sepolia.json
@@ -8,7 +8,7 @@
             "supported_exchanges": {
                 "Binance": "USDC",
                 "Coinbase": "USD",
-                "Kraken": "USD",
+                "Kraken": "USDC",
                 "Okx": "USDC"
             },
             "canonical_exchange": "Binance"

--- a/mainnet.json
+++ b/mainnet.json
@@ -8,7 +8,7 @@
             "supported_exchanges": {
                 "Binance": "USDC",
                 "Coinbase": "USD",
-                "Kraken": "USD",
+                "Kraken": "USDC",
                 "Okx": "USDC"
             },
             "chain_addresses": {

--- a/testnet.json
+++ b/testnet.json
@@ -8,7 +8,7 @@
       "supported_exchanges": {
         "Binance": "USDC",
         "Coinbase": "USD",
-        "Kraken": "USD",
+        "Kraken": "USDC",
         "Okx": "USDC"
       },
       "chain_addresses": {


### PR DESCRIPTION
### Purpose
This PR sets USDC's ticker on the Kraken exchange to be USDC instead of USD. 

The canonical exchange of SPX on Base is Kraken, so we need to be able to convert USD quoted prices to USDC.

Source: [Tradeable Asset Pairs endpoint](https://api.kraken.com/0/public/AssetPairs?pair=USDC/USD)

### Testing
- [ ] Tested locally
- [ ] Test in testnet