### PR TITLE
base-sepolia: set weth canonical exchange

### DIFF
--- a/base-sepolia.json
+++ b/base-sepolia.json
@@ -50,7 +50,7 @@
                 "Kraken": "ETH",
                 "Okx": "ETH"
             },
-            "canonical_exchange": "Okx"
+            "canonical_exchange": "Binance"
         },
         {
             "name": "Virtual Protocol",


### PR DESCRIPTION
### Purpose
This PR properly sets WETH canonical exchange to Binance.
