### PR TITLE
arb, base: update USDT exchange ticker

### DIFF
--- a/arbitrum-one.json
+++ b/arbitrum-one.json
@@ -25,8 +25,8 @@
             "decimals": 6,
             "supported_exchanges": {
                 "Binance": "USDT",
-                "Coinbase": "USD",
-                "Kraken": "USD",
+                "Coinbase": "USDT",
+                "Kraken": "USDT",
                 "Okx": "USDT"
             },
             "logo_url": "https://raw.githubusercontent.com/renegade-fi/token-mappings/refs/heads/main/token-logos/usdt.png",

--- a/arbitrum-sepolia.json
+++ b/arbitrum-sepolia.json
@@ -25,8 +25,8 @@
       "decimals": 6,
       "supported_exchanges": {
         "Binance": "USDT",
-        "Coinbase": "USD",
-        "Kraken": "USD",
+        "Coinbase": "USDT",
+        "Kraken": "USDT",
         "Okx": "USDT"
       },
       "logo_url": "https://raw.githubusercontent.com/renegade-fi/token-mappings/refs/heads/main/token-logos/usdt.png",

--- a/base-mainnet.json
+++ b/base-mainnet.json
@@ -21,8 +21,8 @@
             "decimals": 6,
             "supported_exchanges": {
                 "Binance": "USDT",
-                "Coinbase": "USD",
-                "Kraken": "USD",
+                "Coinbase": "USDT",
+                "Kraken": "USDT",
                 "Okx": "USDT"
             },
             "logo_url": "https://raw.githubusercontent.com/renegade-fi/token-mappings/refs/heads/main/token-logos/usdt.png",

--- a/base-sepolia.json
+++ b/base-sepolia.json
@@ -21,8 +21,8 @@
             "decimals": 6,
             "supported_exchanges": {
                 "Binance": "USDT",
-                "Coinbase": "USD",
-                "Kraken": "USD",
+                "Coinbase": "USDT",
+                "Kraken": "USDT",
                 "Okx": "USDT"
             },
             "logo_url": "https://raw.githubusercontent.com/renegade-fi/token-mappings/refs/heads/main/token-logos/usdt.png",


### PR DESCRIPTION
### Purpose
This PR updates exchange tickers for USDT on Coinbase, Kraken. Confirmed by manually hitting `supports_pair` endpoints: 
- Coinbase supports USDT-USD, not USD-USD
- Kraken supports USDT-uSD, not USD-USD

All callers of `get_exchange_ticker` check for exchange support, i.e. in the external price reporter. This change allows the frontend to stream exchange-specific prices for USDT.

### Testing
- [x] Tested on locally running price reporter and local token remap
- [ ] Test in testnet