### PR TITLE
arb, base: update USDT exchange ticker

### DIFF
--- a/arbitrum-one.json
+++ b/arbitrum-one.json
@@ -25,8 +25,8 @@
             "decimals": 6,
             "supported_exchanges": {
                 "Binance": "USDT",
-                "Coinbase": "USD",
-                "Kraken": "USD",
+                "Coinbase": "USDT",
+                "Kraken": "USDT",
                 "Okx": "USDT"
             },
             "logo_url": "https://raw.githubusercontent.com/renegade-fi/token-mappings/refs/heads/main/token-logos/usdt.png",

--- a/arbitrum-sepolia.json
+++ b/arbitrum-sepolia.json
@@ -25,8 +25,8 @@
       "decimals": 6,
       "supported_exchanges": {
         "Binance": "USDT",
-        "Coinbase": "USD",
-        "Kraken": "USD",
+        "Coinbase": "USDT",
+        "Kraken": "USDT",
         "Okx": "USDT"
       },
       "logo_url": "https://raw.githubusercontent.com/renegade-fi/token-mappings/refs/heads/main/token-logos/usdt.png",

--- a/base-mainnet.json
+++ b/base-mainnet.json
@@ -21,8 +21,8 @@
             "decimals": 6,
             "supported_exchanges": {
                 "Binance": "USDT",
-                "Coinbase": "USD",
-                "Kraken": "USD",
+                "Coinbase": "USDT",
+                "Kraken": "USDT",
                 "Okx": "USDT"
             },
             "logo_url": "https://raw.githubusercontent.com/renegade-fi/token-mappings/refs/heads/main/token-logos/usdt.png",

--- a/base-sepolia.json
+++ b/base-sepolia.json
@@ -21,8 +21,8 @@
             "decimals": 6,
             "supported_exchanges": {
                 "Binance": "USDT",
-                "Coinbase": "USD",
-                "Kraken": "USD",
+                "Coinbase": "USDT",
+                "Kraken": "USDT",
                 "Okx": "USDT"
             },
             "logo_url": "https://raw.githubusercontent.com/renegade-fi/token-mappings/refs/heads/main/token-logos/usdt.png",


### PR DESCRIPTION
### Purpose
This PR updates the exchange ticker for USDT on Coinbase and Kraken. I used the `supports_pair` endpoint to verify these markets were valid: 
- Coinbase supports USDT/USD
- Kraken supports USDT/USD

This is required for the price reporter to stream prices for these exchanges.

### Testing
- [ ] Tested locally that consumers can stream Kraken prices from USDT/USD and not USD/USD
- [ ] Test in testnet